### PR TITLE
fix wrong arg for endswith function

### DIFF
--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -12,7 +12,7 @@ def main():
                 with open(path, 'rb') as f:
                     contents = f.read()
 
-                if not contents.endswith('\n'):
+                if not contents.endswith(b'\n'):
                     with open(path, 'wb') as f:
                         f.write((contents + b'\n').lstrip())
 


### PR DESCRIPTION
The 'arg' of endswith() should be binary type which matches with the
type of 'contents'.