### PR TITLE
Reference cookiecutter project docs in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 ## What is this?
 
-A default template for a new CLI project, written in Python.  Deals with all
-the boilerplate involved in the setuptools setup, etc.
+A default template for a new CLI project, written in Python, to be used
+with the [cookiecutter](https://cookiecutter.readthedocs.io) utility. 
+Deals with all the boilerplate involved in the setuptools setup, etc.
 
 
 ## How do I use this?


### PR DESCRIPTION
I came across this repo by reading [your blogpost](http://nvie.com/posts/writing-a-cli-in-python-in-under-60-seconds/), but I think for others who stumble directly on it and do not know cookiecutter it is useful to have a link right in the README.md. (I might also be useful to link that blog post but thats more a editorial decision.)